### PR TITLE
[Ubuntu 18.04] Fix issue with gnomeVersion value

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ dir=$(dirname $0)
 gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
 if [ -f /usr/share/gnome/gnome-version.xml ];
 then
-  gnomeVersion=$(cat /usr/share/gnome/gnome-version.xml | grep "platform\|minor\|micro" | grep -o -E '[0-9]+' | xargs | sed 's/ /./g')
+  gnomeVersion=$(cat /usr/share/gnome/gnome-version.xml | grep "platform\|minor\|micro" | grep -oE '[0-9]+' | xargs | sed 's/ /./g')
 fi
 
 # newGnome=1 if the gnome-terminal version >= 3.8

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,10 @@ COLOR="default"
 
 dir=$(dirname $0)
 gnomeVersion="$(expr "$(gnome-terminal --version)" : '.* \(.*[.].*[.].*\)$')"
+if [ -f /usr/share/gnome/gnome-version.xml ];
+then
+  gnomeVersion=$(cat /usr/share/gnome/gnome-version.xml | grep "platform\|minor\|micro" | grep -o -E '[0-9]+' | xargs | sed 's/ /./g')
+fi
 
 # newGnome=1 if the gnome-terminal version >= 3.8
 if [[ ("$(echo "$gnomeVersion" | cut -d"." -f1)" = "3" && \


### PR DESCRIPTION
The output format for `gnome-terminal --version` in Ubuntu 18.04 is:
```
# GNOME Terminal 3.28.2 using VTE 0.52.2 +GNUTLS -PCRE2
```
The command at https://github.com/pricco/gnome-terminal-colors-monokai/blob/master/install.sh#L13 wrongly fetches the version as `0.52.2 +GNUTLS -PCRE2`